### PR TITLE
Add recent history to GPT prompt

### DIFF
--- a/app/api/generate-entry/route.ts
+++ b/app/api/generate-entry/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import OpenAI from 'openai';
 import { JournalEntry } from '@/app/types';
+import supabase from '@/app/lib/supabase';
 
 // Initialiser OpenAI
 const openai = new OpenAI({
@@ -18,24 +19,33 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+
+    // Récupérer les 3 à 5 dernières entrées pour fournir du contexte
+    const { data: recentEntries } = await supabase
+      .from('journal_entries')
+      .select('date, mit')
+      .order('date', { ascending: false })
+      .limit(5);
+
+    let historySummary = '';
+    if (recentEntries && recentEntries.length > 0) {
+      historySummary = recentEntries
+        .map((e) => `${e.date}: ${e.mit}`)
+        .join('\n');
+    }
     
-    // Générer l'entrée structurée avec GPT-4
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [
-        {
-          role: 'system',
-          content: `Tu es un assistant qui aide à structurer des entrées de journal.
+    // Construire le prompt système avec l'historique récent s'il existe
+    let systemPrompt = `Tu es un assistant qui aide à structurer des entrées de journal.
           L'utilisateur te donne un prompt vocal décrivant sa journée, ses pensées, ou répondant à certaines questions.
           Ta tâche est de générer une entrée de journal structurée avec les champs suivants:
           1. MIT (Most Important Task): la tâche la plus importante du jour, en une phrase concise
           2. Content: le contenu principal de l'entrée, développé sur plusieurs phrases
           3. Gratitude: liste de 1 à 3 éléments dont l'utilisateur semble reconnaissant
           4. Notes: évaluation de 1 à 10 pour: productivite, sport, energie, proprete, art
-          
-          IMPORTANT: Pour les notes, essaie d'inférer des valeurs pertinentes basées sur le prompt. 
+
+          IMPORTANT: Pour les notes, essaie d'inférer des valeurs pertinentes basées sur le prompt.
           Si une valeur n'est pas mentionnée, utilise 5 comme valeur par défaut.
-          
+
           RÉPONDS UNIQUEMENT AU FORMAT JSON suivant:
           {
             "mit": "string",
@@ -48,7 +58,19 @@ export async function POST(request: NextRequest) {
               "proprete": number,
               "art": number
             }
-          }`
+          }`;
+
+    if (historySummary) {
+      systemPrompt += `\n\nHistorique récent:\n${historySummary}`;
+    }
+
+    // Générer l'entrée structurée avec GPT-4
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        {
+          role: 'system',
+          content: systemPrompt
         },
         {
           role: 'user',


### PR DESCRIPTION
## Summary
- fetch last few journal entries from Supabase in `generate-entry` API
- append a summary of recent MITs to the system prompt before calling OpenAI

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68665add8e848320a5e6ade4f1b9618d